### PR TITLE
Banner between card contents

### DIFF
--- a/src/component/card-chart/index.tsx
+++ b/src/component/card-chart/index.tsx
@@ -7,7 +7,7 @@ import CardWithPrice from './components/card-with-price';
 
 const MainCardChart: FC = () => {
    return (
-      <Grid container py={5}>
+      <Grid container py={5} pt={10}>
          <Grid item md={4} sm={6} xs={12} smMobile={12} mdMobile={12} lgMobile={12}>
             <CardWithAirplane />
          </Grid>


### PR DESCRIPTION
Add padding between banner to map content
[Linear](https://linear.app/bilingual/issue/BIL-60/client-role-add-padding-banner-between-cards)